### PR TITLE
Use Ex4amp1e/.github go 1.23.1 workflows

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -9,6 +9,6 @@ on:
 jobs:
   automerge:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot'}}
-    uses: networkservicemesh/.github/.github/workflows/automerge.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/automerge.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   golangci-lint:
     uses: Ex4amp1e/.github/.github/workflows/golangci-lint.yaml@main
     with:
-      linter-version: v1.53.3
+      linter-version: v1.60.3
 
   exclude-fmt-errorf:
     uses: Ex4amp1e/.github/.github/workflows/exclude-fmt-errorf.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,34 +7,34 @@ on:
       - "release/**"
 jobs:
   yamllint:
-    uses: networkservicemesh/.github/.github/workflows/yamllint.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/yamllint.yaml@main
 
   build-and-test:
-    uses: networkservicemesh/.github/.github/workflows/build-and-test.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/build-and-test.yaml@main
     with:
       os: '["ubuntu-latest", "macos-latest", "windows-latest"]'
 
   golangci-lint:
-    uses: networkservicemesh/.github/.github/workflows/golangci-lint.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/golangci-lint.yaml@main
     with:
       linter-version: v1.53.3
 
   exclude-fmt-errorf:
-    uses: networkservicemesh/.github/.github/workflows/exclude-fmt-errorf.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/exclude-fmt-errorf.yaml@main
 
   restrict-nsm-deps:
-    uses: networkservicemesh/.github/.github/workflows/restrict-nsm-deps.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/restrict-nsm-deps.yaml@main
     with:
       allowed_repositories: "api"
 
   checkgomod:
-    uses: networkservicemesh/.github/.github/workflows/checkgomod.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/checkgomod.yaml@main
 
   gogenerate:
-    uses: networkservicemesh/.github/.github/workflows/sdk-gogenerate.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/sdk-gogenerate.yaml@main
 
   exclude-replace:
-    uses: networkservicemesh/.github/.github/workflows/exclude-replace.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/exclude-replace.yaml@main
 
   code-cov:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -17,4 +17,4 @@ on:
 
 jobs:
   analyze:
-    uses: networkservicemesh/.github/.github/workflows/codeql-analysis.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/codeql-analysis.yaml@main

--- a/.github/workflows/pr-for-updates.yaml
+++ b/.github/workflows/pr-for-updates.yaml
@@ -6,6 +6,6 @@ on:
       - update/**
 jobs:
   auto-pull-request:
-    uses: networkservicemesh/.github/.github/workflows/pr-for-updates.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/pr-for-updates.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,14 +31,14 @@ jobs:
   create-release:
     name: Create release
     needs: get-tag
-    uses: networkservicemesh/.github/.github/workflows/release.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/release.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
 
   release-dependent-repositories:
     name: Release dependent repositories
     needs: [get-tag, create-release]
-    uses: networkservicemesh/.github/.github/workflows/release-dependent-repositories.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/release-dependent-repositories.yaml@main
     with:
       tag: ${{ needs.get-tag.outputs.tag }}
       dependent_repositories: |

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   update-dependent-repositories:
-    uses: networkservicemesh/.github/.github/workflows/update-dependent-repositories-gomod.yaml@main
+    uses: Ex4amp1e/.github/.github/workflows/update-dependent-repositories-gomod.yaml@main
     with:
       dependent_repositories: |
         ["sdk-k8s",


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Proof of concept, that go upgrade in .github repository doesn't break builds.

## Issue link
https://github.com/networkservicemesh/.github/pull/85
